### PR TITLE
fix(draft): conclude carbonite drafts when packs are unequal size (#19)

### DIFF
--- a/src/utils/draftAdvance.test.ts
+++ b/src/utils/draftAdvance.test.ts
@@ -1,6 +1,6 @@
 import { describe, it } from 'node:test'
 import assert from 'node:assert'
-import { parseCurrentPack, isPackPickComplete } from './draftAdvance'
+import { parseCurrentPack, isPackPickComplete, isPackRoundExhausted, isStagedPickResolved } from './draftAdvance'
 
 describe('draftAdvance pack completion', () => {
   describe('parseCurrentPack', () => {
@@ -35,6 +35,67 @@ describe('draftAdvance pack completion', () => {
       } as never)
 
       assert.strictEqual(complete, false)
+    })
+  })
+
+  // Issue #19: a Carbonite pack carries one extra draftable card, so packs can
+  // be unequal size. The round must stay alive until the largest pack is empty,
+  // and an already-empty seat must not block the final pick — otherwise the
+  // draft hangs on the last round.
+  describe('isPackRoundExhausted (issue #19 — carbonite/uneven packs)', () => {
+    const card = { id: 'c1', name: 'Card 1' }
+
+    it('FIXED: round is NOT exhausted while a larger Carbonite pack still has a card', () => {
+      const players = [
+        { current_pack: [] },        // depleted standard pack
+        { current_pack: '[]' },      // depleted standard pack (JSON form)
+        { current_pack: [card] },    // Carbonite pack — extra card still to draft
+      ]
+      assert.strictEqual(
+        isPackRoundExhausted(players as never), false,
+        'SPEC: keep drafting until the Carbonite pack\'s extra card is taken'
+      )
+    })
+
+    it('FIXED: round is exhausted only when EVERY pack is empty', () => {
+      const players = [
+        { current_pack: [] },
+        { current_pack: '[]' },
+        { current_pack: [] },
+      ]
+      assert.strictEqual(isPackRoundExhausted(players as never), true)
+    })
+
+    it('BUGGY-BEFORE: an empty seat 0 no longer ends the round on its own', () => {
+      // Old code keyed off players[0]; seat 0 empty while another seat holds a
+      // card would wrongly end/hang the round. Now it stays active.
+      const players = [
+        { current_pack: [] },
+        { current_pack: [card] },
+      ]
+      assert.strictEqual(isPackRoundExhausted(players as never), false)
+    })
+  })
+
+  describe('isStagedPickResolved (issue #19 — empty packs must not block)', () => {
+    const card = { id: 'c1', name: 'Card 1' }
+
+    it('FIXED: an empty-pack player is resolved without selecting', () => {
+      assert.strictEqual(isStagedPickResolved({
+        pick_status: 'picking', selected_card_id: null, current_pack: [],
+      } as never), true)
+    })
+
+    it('a player who has selected a card is resolved', () => {
+      assert.strictEqual(isStagedPickResolved({
+        pick_status: 'selected', selected_card_id: 'c1', current_pack: [card],
+      } as never), true)
+    })
+
+    it('a player still holding cards but not selected is NOT resolved', () => {
+      assert.strictEqual(isStagedPickResolved({
+        pick_status: 'picking', selected_card_id: null, current_pack: [card],
+      } as never), false)
     })
   })
 })

--- a/src/utils/draftAdvance.ts
+++ b/src/utils/draftAdvance.ts
@@ -123,6 +123,38 @@ export function isPackPickComplete(player: Pick<DraftPlayer, 'pick_status' | 'cu
 }
 
 /**
+ * A pack round is exhausted only when EVERY player's pack is empty.
+ *
+ * Uniform packs deplete in lockstep, so for a normal draft this is equivalent
+ * to the old single-seat (players[0]) check. But Carbonite packs carry one
+ * extra draftable card, so packs can be unequal size — checking only seat 0
+ * would declare the round over (and complete the draft) while another seat
+ * still holds the Carbonite pack's last card, hanging the final round (#19).
+ * Requiring ALL packs empty lets that extra card get drafted and the draft
+ * conclude.
+ */
+export function isPackRoundExhausted(
+  players: Pick<DraftPlayer, 'current_pack'>[]
+): boolean {
+  return players.length > 0 &&
+    players.every(p => parseCurrentPack(p.current_pack).length === 0)
+}
+
+/**
+ * Whether a player has resolved their pick for the current staged round.
+ * Resolved = they selected a card, OR their pack is already empty (nothing left
+ * to pick — e.g. a depleted standard pack while a larger Carbonite pack is
+ * still being drafted). Empty-pack players must NOT block the round, otherwise
+ * an uneven-pack (Carbonite) draft can never finish its final pick (#19).
+ */
+export function isStagedPickResolved(
+  player: Pick<DraftPlayer, 'pick_status' | 'selected_card_id' | 'current_pack'>
+): boolean {
+  if (player.pick_status === 'selected' && player.selected_card_id) return true
+  return parseCurrentPack(player.current_pack).length === 0
+}
+
+/**
  * Process all staged picks when all players have selected
  * This is the "staged pick" system where:
  * 1. Players select cards (stored in selected_card_id)
@@ -170,9 +202,12 @@ export async function processAllStagedPicks(podId: string): Promise<boolean> {
       return false
     }
 
-    // Double-check ALL players are in 'selected' status before processing
-    // This prevents partial processing if some picks already went through
-    const allSelected = players.every(p => p.pick_status === 'selected' && p.selected_card_id)
+    // Double-check ALL players are resolved before processing. A player whose
+    // pack is empty (a depleted standard pack while a larger Carbonite pack is
+    // still in play) counts as resolved — otherwise an uneven-pack draft can
+    // never finish its final pick (#19). This prevents partial processing while
+    // still letting the Carbonite holder's last pick go through.
+    const allSelected = players.every(isStagedPickResolved)
     if (!allSelected) {
       // Not all players have selected - don't process yet
       return false
@@ -444,11 +479,9 @@ async function advancePackDraftAfterPicks(
   const pickInPack = draftState.pickInPack || 1
   const totalPacks = getTotalPacks(draftState, pod)
 
-  // Check if current pack is exhausted
-  const firstPlayer = players[0]
-  const remainingPack: RawCard[] = parseCurrentPack(firstPlayer.current_pack)
-
-  if (remainingPack.length === 0) {
+  // The pack round is over only when EVERY player's pack is empty. Keying off a
+  // single seat breaks on uneven Carbonite packs (#19) — see isPackRoundExhausted.
+  if (isPackRoundExhausted(players)) {
     if (packNumber >= totalPacks) {
       // Draft complete
       await tx.query(
@@ -634,7 +667,7 @@ export async function checkAndAdvanceLeaderDraft(
         [podId]
       )
     } else {
-      // Round 3 complete - transition to pack draft phase
+      // Final leader round complete - transition to pack draft phase
       draftState.phase = 'pack_draft'
       draftState.packNumber = 1
       draftState.pickInPack = 1
@@ -727,7 +760,9 @@ export async function checkAndAdvancePackDraft(
       [podId]
     )
 
-    const allPicked = players.every(p => p.pick_status === 'picked')
+    // Empty packs count as complete so uneven Carbonite packs don't hang (#19);
+    // mirrors the leader path, which already uses isPackPickComplete.
+    const allPicked = players.every(isPackPickComplete)
     if (!allPicked) {
       // Just increment state version
       await tx.query(


### PR DESCRIPTION
Fixes #19.

## Problem
`advancePackDraftAfterPicks` decided a pack round was exhausted from `players[0].current_pack` **only**, and the staged/legacy pick gates didn't treat an empty pack as "resolved." Carbonite packs carry one extra draftable card, so packs are unequal size — the round could end (or the draft complete) while another seat still held the Carbonite pack's last card. Symptom: *"couldn't conclude the draft… the last player received the Carb pack and had one more card than everyone else."*

## Fix
- **`isPackRoundExhausted(players)`** — a pack round ends only when **every** pack is empty, so the larger Carbonite pack keeps the round alive until its extra card is drafted.
- **empty pack ⇒ resolved** in the pick gates (`isStagedPickResolved`; reuse existing `isPackPickComplete`) so a depleted seat doesn't block the Carbonite holder's final pick.
- Wired into `processAllStagedPicks`, `advancePackDraftAfterPicks`, and `checkAndAdvancePackDraft`.

## Safety
Uniform (non-Carbonite) drafts are unaffected — packs deplete in lockstep, so *all-empty ≡ seat-0-empty*. The Carbonite holder ends with one extra card, which is by design (Carbonite = more cards). Per-set behavior unchanged.

## Tests
Spec-first unit tests for both helpers (uneven/carbonite + empty-pack-doesn't-block). Full unit suite green — 1648 pass; the only failures are 3 **pre-existing, unrelated** ones (PostHog capture assertion + OMR python-sidecar tests, neither imports `draftAdvance`). `npm run build` compiles clean.

## Note
Core draft logic — worth a real Carbonite playtest (or a draft E2E) before prod deploy. **Supersedes #21**, which targeted the pre-staged-pick architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)