### PR TITLE
fix(draft-log): keep Wayfinder Companion badge/overlay out of card flow

### DIFF
--- a/app/draft/[shareId]/log/log.css
+++ b/app/draft/[shareId]/log/log.css
@@ -146,39 +146,6 @@
   }
 }
 
-/* Host-level lock button in top nav */
-.draft-log-host-lock {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.4rem 0.75rem;
-  background: rgba(255, 255, 255, 0.08);
-  border: 1px solid rgba(255, 255, 255, 0.2);
-  border-radius: 6px;
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 0.8rem;
-  font-family: 'Barlow', sans-serif;
-  cursor: pointer;
-  transition: all 0.2s ease;
-}
-
-.draft-log-host-lock.lock-private {
-  color: #ff6b6b;
-  border-color: rgba(255, 107, 107, 0.3);
-}
-
-.draft-log-host-lock.lock-public {
-  color: #81c784;
-  border-color: rgba(129, 199, 132, 0.3);
-}
-
-@media (hover: hover) and (pointer: fine) {
-  .draft-log-host-lock:hover {
-    background: rgba(255, 255, 255, 0.15);
-    color: rgba(255, 255, 255, 0.9);
-  }
-}
-
 /* Tabs - folder/tab style matching stats page */
 .draft-log-tabs {
   display: flex;

--- a/app/draft/[shareId]/log/page.tsx
+++ b/app/draft/[shareId]/log/page.tsx
@@ -439,14 +439,15 @@ export default function DraftLogPage({ params }: PageProps) {
             Download JSON
           </Button>
           {meta.isHost && (
-            <button
-              className={`draft-log-host-lock ${meta.isDraftPublic ? 'lock-public' : 'lock-private'}`}
+            <Button
+              variant="secondary"
               onClick={handleToggleDraftPublic}
               title={meta.isDraftPublic ? 'Draft is public - click to make private' : 'Draft is private - click to make public'}
+              style={{ color: meta.isDraftPublic ? '#81c784' : '#ff6b6b' }}
             >
               {meta.isDraftPublic ? <LockOpen size={14} /> : <LockClosed size={14} />}
-              <span>{meta.isDraftPublic ? 'Public' : 'Private'}</span>
-            </button>
+              {meta.isDraftPublic ? 'Public' : 'Private'}
+            </Button>
           )}
         </div>
 

--- a/src/components/Card.css
+++ b/src/components/Card.css
@@ -102,7 +102,12 @@
   border-radius: calc(var(--rainbow-border-radius) + var(--rainbow-border-size));
 }
 
-.canvas-card > * {
+/* The card's own children clip to the rounded frame. Exclude the Wayfinder
+   Companion's injected badge/overlay (.wf-ptp-*): they position themselves
+   absolutely over the card, and must not be pulled into the card's flow/clip —
+   otherwise the stats badge drops below the image and grows the card, which the
+   rainbow selection ring then wraps as a "bleed" below the card. */
+.canvas-card > *:not(.wf-ptp-card-stat-badge):not(.wf-ptp-card-stats-overlay) {
   border-radius: 11px;
   overflow: hidden;
 }
@@ -247,7 +252,9 @@
   pointer-events: none;
 }
 
-.canvas-card > * {
+/* See note above: keep the Wayfinder Companion's injected badge/overlay out of
+   this rule so their absolute positioning + high z-index survive. */
+.canvas-card > *:not(.wf-ptp-card-stat-badge):not(.wf-ptp-card-stats-overlay) {
   position: relative;
   z-index: 1;
 }


### PR DESCRIPTION
## Problem
On the draft log, the Wayfinder Companion's injected stats **badge** rendered at the bottom-**left** with an orange "rainbow bleed" below leader cards (see reports). The badge is meant to sit bottom-right with an in-card overlay on click, like everywhere else.

## Root cause
The Companion injects an absolutely-positioned `.wf-ptp-card-stat-badge` (bottom-right) and `.wf-ptp-card-stats-overlay` (inset:0) into card surfaces. PTP's broad `.canvas-card > *` rules (`position: relative; z-index: 1; overflow: hidden`) matched those injected children at **equal specificity**, and because app CSS loads *after* the extension's injected styles in production, it won the cascade — forcing the badge into normal flow. That dropped it bottom-left and grew the card below the image, which the rainbow selection ring wrapped as a "bleed."

## Fix
Exclude `.wf-ptp-card-stat-badge` / `.wf-ptp-card-stats-overlay` from both `.canvas-card > *` rules so the plugin's own absolute positioning survives. No change to the card's own children (verified: leaders 168×120, units 120×168 unchanged without the plugin).

Also swaps the hand-rolled draft-log host-lock button for the shared `<Button>` component to match the other top-nav buttons.

A companion `!important` hardening change ships in the Wayfinder extension repo (defense-in-depth for other host sites).

## Verification
- Reproduced the bug in the live DOM (badge → `position: relative`, bottom-left, card grew 149px vs 120px) and confirmed the fix restores absolute bottom-right + in-card overlay with no growth.
- Production build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)