### PR TITLE
fix(lobby): only offer Karabast findability on public games

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 08.01.2026 Part 2
+
+### 🔒 Bug Fixes
+- **"Findable by Karabast users" only appears on public lobbies.** It was offered on private ones too, and because the setting is remembered between lobbies, a private lobby could be listed publicly on Karabast without you touching the checkbox — the opposite of what "Private" means.
+
 ## 08.01.2026
 
 ### 🎉 Karabast Games Show Up For Everyone

--- a/src/components/Lobby/PostGameModal.tsx
+++ b/src/components/Lobby/PostGameModal.tsx
@@ -2,8 +2,8 @@
 
 /**
  * New Game modal (R28/R31/R32/R34): pick a deck (it sets the game's
- * set+format), choose Public vs Private link, and — with a capable
- * Companion — pre-create the Karabast lobby (default ON).
+ * set+format), choose Public vs Private, and — on a PUBLIC game with a capable
+ * Companion — pre-create the Karabast lobby so Karabast users can find it.
  */
 import { useEffect, useState } from 'react'
 import Modal from '@/src/components/Modal'
@@ -38,6 +38,15 @@ export default function PostGameModal({
 
   const selectedShareId = selected?.poolShareId ?? initialPoolShareId
 
+  // Listing on Karabast is a PUBLIC-only affordance: a private lobby is
+  // link-only, so publishing it to Karabast's public list would contradict the
+  // choice the user just made. Derived once and used for BOTH the checkbox and
+  // the value handed to onCreated, so the two can't drift — the preference is
+  // remembered in localStorage, so `createKarabast` can be true on open without
+  // the user having touched it this session.
+  const karabastOffered = companionCapable && visibility === 'public'
+  const karabastFindable = karabastOffered && createKarabast
+
   async function createGame(): Promise<void> {
     if (!selectedShareId || busy) return
     setBusy(true)
@@ -53,7 +62,7 @@ export default function PostGameModal({
         throw new Error(json?.message || 'Could not create the game')
       }
       const game = (json.data || json).game
-      onCreated(game, companionCapable && createKarabast)
+      onCreated(game, karabastFindable)
     } catch (error) {
       showToast({
         text: error instanceof Error ? error.message : 'Could not create the game',
@@ -88,7 +97,7 @@ export default function PostGameModal({
             Private
           </Button>
         </div>
-        {companionCapable && (
+        {karabastOffered && (
           <label className="lobby-check lobby-check-centered">
             <input
               type="checkbox"

--- a/src/data/cards.json
+++ b/src/data/cards.json
@@ -351686,7 +351686,7 @@
       "spoiledNormalCount": 264,
       "status": "valid",
       "contradictions": [],
-      "generatedAt": "2026-08-02T01:58:21.518Z"
+      "generatedAt": "2026-08-02T02:38:41.865Z"
     },
     "lastProcessed": "2026-08-02"
   }


### PR DESCRIPTION
"Findable by Karabast users" rendered whenever the Companion was capable, regardless of Public/Private — and the flag passed to `onCreated` was `companionCapable && createKarabast`, with no visibility check either.

That second half is the real bug. The preference is remembered in `localStorage`, so `createKarabast` can already be `true` when the modal opens. A host who had ever used it, then made a **private** lobby, would silently have it claimed and published to Karabast's public list — the opposite of the choice they just made. Hiding the checkbox alone would have left that intact.

Both the checkbox and the value handed to `onCreated` now derive from one boolean, so display and behaviour can't drift.

## Verification

Exercised against the `/api/open-games/{id}/claim` call that actually publishes, with the preference pre-set ON:

| case | checkbox | `/claim` fired | published |
|---|---|---|---|
| Private, preference ON | hidden | none | **no** |
| Public, preference ON | shown + checked | `/api/open-games/fake-2/claim` | yes |

Checkbox shows on Public, hides on Private, returns on Public.

`typecheck`, `check:ts-ratchet`, `check:design-tells`, `lint`, `npm run test` (2466 tests, 0 fail), production `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)