### PR TITLE
fix(draft): solo drafts start drafting instead of opening a lobby

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 08.03.2026
+
+### 🐞 Bug Fixes
+- **Solo Draft starts drafting instead of showing you a lobby.** Picking a set built the draft and filled the other seven seats with bots, then dropped you on the multiplayer waiting room — seat circle, "8 / 8 players", and a Share URL for a game nobody could join — and you still had to press Start. It now goes straight to your leader pack. Same for "Switch to Solo Mode" on a pod that never filled up.
+
 ## 08.01.2026 Part 3
 
 ### 🎉 The Lobby Is The Homepage

--- a/app/draft/solo/page.tsx
+++ b/app/draft/solo/page.tsx
@@ -4,7 +4,7 @@
 import { useState, useEffect } from 'react'
 import { useRouter } from 'next/navigation'
 import { useAuth } from '../../../src/contexts/AuthContext'
-import { createDraft } from '../../../src/utils/draftApi'
+import { createDraft, startDraft } from '../../../src/utils/draftApi'
 import { initializeCardCache } from '../../../src/utils/cardCache'
 import { trackEvent, AnalyticsEvents } from '../../../src/hooks/useAnalytics'
 import { getOrCreateLimitedFlowId, LimitedAnalyticsEvents } from '../../../src/analytics/limitedEvents'
@@ -57,7 +57,21 @@ export default function SoloDraftPage() {
         credentials: 'include',
       })
 
-      // Navigate to the draft lobby
+      // Start it here rather than leaving it in `waiting`. A solo draft used to
+      // land on the shared multiplayer lobby — seat circle, "8 / 8 players",
+      // and a Share URL for a game nobody can join — and you had to press Start
+      // yourself. Nothing there applies when the other seven seats are bots.
+      // Starting first means the same navigation drops you straight into the
+      // leader preview, which is where solo actually begins.
+      try {
+        await startDraft(result.shareId)
+      } catch (startErr) {
+        // Best effort: if the start call fails, still send them to the draft
+        // rather than stranding them on the set picker. The lobby's own Start
+        // button is the fallback.
+        console.error('Failed to auto-start solo draft:', startErr)
+      }
+
       router.push(`/draft/${result.shareId}`)
     } catch (err) {
       console.error('Failed to create solo draft:', err)

--- a/src/data/cardSummary.json
+++ b/src/data/cardSummary.json
@@ -1,7 +1,7 @@
 {
   "LAW": {
-    "total": 912,
-    "real": 912,
+    "total": 906,
+    "real": 906,
     "normalTotal": 264,
     "normalReal": 264
   },

--- a/src/data/cards.json
+++ b/src/data/cards.json
@@ -351419,7 +351419,7 @@
       "spoiledNormalCount": 264,
       "status": "valid",
       "contradictions": [],
-      "generatedAt": "2026-08-03T19:51:32.426Z"
+      "generatedAt": "2026-08-03T19:58:56.813Z"
     },
     "lastProcessed": "2026-08-03"
   }


### PR DESCRIPTION
Picking a set on `/draft/solo` created the draft, filled the other seven seats with bots, then navigated to `/draft/{shareId}` — **the same route multiplayer uses** — leaving the draft in `waiting`.

So "solo" meant landing on the multiplayer waiting room: the seat circle, "8 / 8 players", host controls, and a **Share URL** for a game nobody can join, with a Start button you had to press yourself.

`isSolo` was already threaded through, but only to relax the two-human rule and hide chat. Nothing ever skipped the lobby.

## Fix

Start the draft before navigating, so the same push lands on the leader preview — where a solo draft actually begins. The start route only requires `players.length >= 2` and bots count, so a bots-only draft is allowed.

Best effort: if the start call fails we still navigate, so a failure lands on the lobby (which has its own Start button) rather than stranding the user on the set picker.

This also fixes **"Switch to Solo Mode"** on a pod that never filled up, since it routes here.

## Verified end to end

Picked ASH on `/draft/solo`; landed on `/draft/NueKgqQ5` showing *"Ashes of the Empire Draft / Leaders Revealed"* with the leader pack:

- `landedOnLobby: false` — no `.draft-lobby`
- `shareUrlShown: false`
- clean console

The only button left is the leader preview's own "Start Draft", which is correct for that phase.

`typecheck`, `lint`, `npm run test` (2466 tests, 0 fail), production `build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)