### PR TITLE
feat(home): live strip + board on the old homepage

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,11 +1,13 @@
 # Release Notes
 
-## 08.04.2026
+## 08.12.2026
 
-### 🎉 Open Games On The Homepage
-- **The homepage shows who's playing.** Open games, draft pods forming, and the limited games running on Karabast now sit under the mode buttons.
-- **The online count says what people are doing** — drafting, building, in solo play — instead of just a total.
-- **With the Wayfinder Companion, joining is one click.** It loads your deck and drops you into the game.
+### 🎉 New Features
+- **Open games are on the homepage.** Games waiting for an opponent, pods forming, and limited games on Karabast — above the mode buttons.
+- **The online count says what people are doing** — drafting, building, solo play.
+
+### 🎨 UI Improvements
+- **"Live Pod" is now "With Friends".**
 
 ## 08.03.2026 Part 2
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,72 +1,36 @@
 # Release Notes
 
+## 08.04.2026
+
+### 🎉 Open Games On The Homepage
+- **The homepage shows who's playing.** Open games, draft pods forming, and the limited games running on Karabast now sit under the mode buttons.
+- **The online count says what people are doing** — drafting, building, in solo play — instead of just a total.
+- **With the Wayfinder Companion, joining is one click.** It loads your deck and drops you into the game.
+
 ## 08.03.2026 Part 2
 
 ### 🐞 Bug Fixes
-- **"Findable by Karabast users" is now remembered on the lobby itself.** Your choice only ever existed in the browser tab you created the lobby in, so anything later had to guess at it from whether the lobby was public — and the guess was wrong both ways round. A public lobby you hadn't marked findable could still be published to Karabast, and a lobby you *had* marked findable could still come out private. The lobby now carries your actual choice, and every path reads it.
+- **"Findable by Karabast users" is remembered on the lobby itself.** The choice only existed in the tab you created it in, so everything afterwards guessed from public/private — and guessed wrong both ways.
 
 ## 08.03.2026
 
 ### 🐞 Bug Fixes
-- **A lobby set to be findable on Karabast now actually shows up there.** Creating the game from the match page always made a *private* Karabast lobby, whatever you'd chosen — so the game was invisible to the Karabast players you'd just advertised it to. It now follows the lobby's own setting: public lobbies get a public Karabast lobby, private ones stay link-only.
-
-## 08.01.2026 Part 3
-
-### 🎉 The Lobby Is The Homepage
-
-**Protect the Pod has always been a great place to open packs and build decks. The part that never worked was the last step: finding someone to play against.**
-
-You'd build something you were proud of, and then… go ask in Discord. Or not bother. The lobby fixes that, and it's now the first thing you see.
-
-**Every open game is on the front page.** Games waiting for an opponent, draft pods forming, and — this is the new part — **the limited games running on Karabast right now.** You can see who's around, what they're playing, and how many people are mid-draft or mid-build, without asking anyone.
-
-Join a game and bring any deck you've built. Post yours and wait for someone. Start a pod. It's all one screen.
-
-### 🔌 The Wayfinder Companion Makes It Seamless
-
-You don't need the Companion for any of this — the board shows you everything either way.
-
-What the Companion does is remove the busywork. Click Join and it loads your deck and drops you straight into the game — no exporting, no copying JSON, no pasting into Karabast, no re-picking your leader. It also records how your games actually went, so your stats fill in on their own.
-
-With it, going from "I built a deck" to "I'm playing a game" is one click.
-
-### 📖 Also
-- The old homepage's links, release notes, and disclaimer all moved across with it — nothing's lost, it's just at the bottom now.
+- **A lobby marked findable on Karabast actually shows up there.** Creating from the match page always made a private Karabast lobby, whatever you'd picked.
 
 ## 08.01.2026 Part 2
 
 ### 🔒 Bug Fixes
-- **"Findable by Karabast users" only appears on public lobbies.** It was offered on private ones too, and because the setting is remembered between lobbies, a private lobby could be listed publicly on Karabast without you touching the checkbox — the opposite of what "Private" means.
+- **"Findable by Karabast users" only appears on public lobbies.** It was offered on private ones too, and since the setting is remembered, a private lobby could get listed on Karabast without you touching it.
 
 ## 08.01.2026
 
-### 🎉 Karabast Games Show Up For Everyone
-
-**There have been live limited games on Karabast this whole time. Unless you had the Companion extension installed, the lobby never showed you a single one.**
-
-The board only ever learned about Karabast games from the extension relaying them out of your own browser. No extension, no games — forever, with no hint anything was missing. Protect the Pod now reads Karabast's public lobby list itself, so the draft and sealed games waiting over there are on the board for everyone.
-
-You can join one with any of your limited decks. Karabast listings don't say which set they want, so the deck picker doesn't guess — every limited deck is offered and the lobby name tells you what the host is after.
-
-### 🎮 A Calmer Lobby
-
-- **The lobby leads with the logo again**, with the online counts underneath it where they used to be.
-- **"Play Now" and "New Lobby" are gone.** Play Now grabbed whichever pool happened to be first — built or not — and then told you to go finish building it. Creating a lobby now lives on the Open Lobbies panel itself.
-- **The whole lobby fits one screen** on a desktop, with no fold. A busy board scrolls inside its own panel instead of pushing everything else off the bottom.
-- **The activity line only counts what's happening.** No more "0 open lobbies · 0 pods forming" — an activity that isn't happening simply isn't listed. "Browsing" is now "solo play".
-
 ### 🐞 Bug Fixes
-
-- **The deck picker stopped hiding its own controls.** The deck list sat in an invisible scrolling window, so the page buttons, the set filters and the public/private choice were all parked below a fold with nothing to indicate they were there. Everything is visible at once now, and the number of decks per page adapts to your screen so it stays that way.
-- **Deck tags stay on one line** instead of wrapping and doubling the height of every row.
-- **The picker opens on the current set**, which is the deck almost everyone is reaching for.
-- **Ashes of the Empire and Jump to Lightspeed count as current sets again.** The list of rotation-legal sets was written out by hand, so it went stale the moment a set released — ASH had been out for three weeks without being added, and JTL had been dropped a year early. Games launched with those decks asked Karabast for the wrong card pool. Rotation is now worked out from the release calendar, so it can't drift again.
-- **"Private link" is just "Private."**
+- **Ashes of the Empire and Jump to Lightspeed count as current sets again.** The rotation-legal set list was kept by hand and had gone stale, so games launched with those decks asked Karabast for the wrong card pool. It's now worked out from the release calendar.
+- **The deck picker shows all of its controls.** Page buttons, set filters and the public/private choice were below an invisible scroll. Tags stay on one line, and it opens on the current set.
 
 ### 🎨 UI Improvements
-- **Leader thumbnails show art, not card edges.** Every small square leader image on the stats pages — the usage legend, the leader list, the match rows, the opponent thumbs — was cropped by its own hand-tuned offset, and most of them let the card's trait bar sit along the bottom of the box. They all now use the same crop as the win-rate grid, which frames the illustration and nothing else. Because that crop is a ratio rather than a pixel nudge, it holds at every thumbnail size instead of drifting back on the small ones.
-- **Chaos pools say "Chaos" in your menu.** A chaos pool's set list ran to `SOR,SOR,GC2026_SILVER,GC2026_BLACK…` and wrapped the menu row onto a second line. In the menu it now reads "Chaos Sealed", the same name it goes by everywhere else.
-- **The Your Open Lobby row is one line.** It said the lobby was waiting for an opponent directly under a heading that already said so. The subtitle now carries just the deck or format that's queued up.
+- **Leader thumbnails show art, not card edges.** Every small leader image on the stats pages now uses the same crop as the win-rate grid, and it holds at any size.
+- **Chaos pools say "Chaos" in your menu** instead of a run of set codes.
 
 ## 07.31.2026 Part 2
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@
 
 import { Suspense, useState, useEffect } from 'react'
 import '../src/App.css'
-import LobbyHome from '../src/components/Lobby/LobbyHome'
+import LandingPage from '../src/components/LandingPage'
 import TermsOfService from '../src/components/TermsOfService'
 import PrivacyPolicy from '../src/components/PrivacyPolicy'
 import About from '../src/components/About'
@@ -65,7 +65,7 @@ export default function Home() {
     <div className="app">
       {view === 'landing' && (
         <Suspense fallback={null}>
-          <LobbyHome />
+          <LandingPage />
         </Suspense>
       )}
       {view === 'terms-of-service' && (

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -670,27 +670,25 @@ a.discord-cta:active {
 }
 
 /* ---- live state on the homepage (A + D) ----------------------------------
-   The presence line's breakdown, and the board that sits below the fold. The
-   hero and the mode columns above are deliberately untouched: the homepage's
-   first impression is the same one it has always had. */
+   The presence line's breakdown, and the board below the fold. The hero and
+   the mode columns above are deliberately untouched: the homepage's first
+   impression is the same one it has always had. */
 .landing-live-line strong {
   color: white;
   font-weight: 600;
 }
 
+/* Same box as .mode-sections-row, so the board's left and right edges land on
+   the button grid's edges rather than running wider than it. */
 .landing-board {
   width: 100%;
-  max-width: 1100px;
-  margin: 0 auto;
-  padding: 0 var(--pt-space-md) var(--pt-space-xl);
-  box-sizing: border-box;
-  text-align: left;
+  max-width: 1200px;
+  margin-top: 2.5rem;
 }
 
-.landing-board-title {
-  margin: 0 0 var(--pt-space-sm);
-  font-size: 1.15rem;
-  font-weight: 600;
-  color: var(--pt-ink);
-  text-align: center;
+/* The board's own columns are sized for the lobby page's narrower container;
+   at this width give Open Lobbies the extra room so its rows (avatar, name,
+   set/format badges, age, Join) sit on one line instead of wrapping. */
+.landing-board .lobby-board {
+  grid-template-columns: 1.7fr 1fr;
 }

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -668,3 +668,29 @@ a.discord-cta:active {
     font-size: 0.65rem;
   }
 }
+
+/* ---- live state on the homepage (A + D) ----------------------------------
+   The presence line's breakdown, and the board that sits below the fold. The
+   hero and the mode columns above are deliberately untouched: the homepage's
+   first impression is the same one it has always had. */
+.landing-live-line strong {
+  color: white;
+  font-weight: 600;
+}
+
+.landing-board {
+  width: 100%;
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 0 var(--pt-space-md) var(--pt-space-xl);
+  box-sizing: border-box;
+  text-align: left;
+}
+
+.landing-board-title {
+  margin: 0 0 var(--pt-space-sm);
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--pt-ink);
+  text-align: center;
+}

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -686,6 +686,10 @@ a.discord-cta:active {
    min-width: 0 chain below lets the board's own contents shrink to fit
    instead of pushing back. */
 .landing-board {
+  /* .landing-content centres everything; the board's rows are left-aligned
+     copy, and inheriting centre made each row's second line sit adrift under
+     the first rather than under the name. */
+  text-align: left;
   align-self: stretch;
   /* width:0 keeps the board out of .landing-content's intrinsic width entirely
      (its max-content is far wider than the buttons), and min-width:100% then

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -670,9 +670,9 @@ a.discord-cta:active {
 }
 
 /* ---- live state on the homepage (A + D) ----------------------------------
-   The presence line's breakdown, and the board below the fold. The hero and
-   the mode columns above are deliberately untouched: the homepage's first
-   impression is the same one it has always had. */
+   The presence line's breakdown, and the live board. The board sits between
+   the hero and the mode buttons: what is happening right now reads before the
+   menu of things you could start. The hero itself is untouched. */
 .landing-live-line strong {
   color: white;
   font-weight: 600;
@@ -697,7 +697,8 @@ a.discord-cta:active {
      the board drags the grid from its natural 739px out to 1200px. */
   width: 0;
   min-width: 100%;
-  margin-top: 2.5rem;
+  /* It sits ABOVE the mode buttons now, so the gap belongs underneath it. */
+  margin-bottom: 2.5rem;
 }
 
 .landing-board .lobby-board,

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -678,12 +678,29 @@ a.discord-cta:active {
   font-weight: 600;
 }
 
-/* Same box as .mode-sections-row, so the board's left and right edges land on
-   the button grid's edges rather than running wider than it. */
+/* The board must FIT the button grid, never widen it. .landing-content is a
+   centred column flex, so a child wider than the buttons drags the whole
+   container out with it — which is what a `width: 100%; max-width: 1200px`
+   board did here, stretching the grid from its natural 739px to 1200px.
+   align-self: stretch fills whatever width the buttons establish, and the
+   min-width: 0 chain below lets the board's own contents shrink to fit
+   instead of pushing back. */
 .landing-board {
-  width: 100%;
-  max-width: 1200px;
+  align-self: stretch;
+  /* width:0 keeps the board out of .landing-content's intrinsic width entirely
+     (its max-content is far wider than the buttons), and min-width:100% then
+     renders it at whatever width the buttons settled on. Without the width:0
+     the board drags the grid from its natural 739px out to 1200px. */
+  width: 0;
+  min-width: 100%;
   margin-top: 2.5rem;
+}
+
+.landing-board .lobby-board,
+.landing-board .lobby-column,
+.landing-board .lobby-row,
+.landing-board .lobby-row-who {
+  min-width: 0;
 }
 
 /* The board's own columns are sized for the lobby page's narrower container;

--- a/src/components/LandingPage.css
+++ b/src/components/LandingPage.css
@@ -315,7 +315,7 @@ a.discord-cta:active {
   }
 }
 
-/* Three-column layout: Solo / Live Pod / Deckbuilder */
+/* Three-column layout: Solo / With Friends / Deckbuilder */
 .mode-sections-row {
   display: flex;
   gap: 2rem;

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -638,20 +638,20 @@ function LandingPage() {
             </div>
           </div>
         </div>
+        {/* The live board, below the fold. Sits inside .landing-content and
+            carries .mode-sections-row's own max-width, so its edges line up
+            with the button grid above rather than running wider. */}
+        <section className="landing-board" aria-label="Open games">
+          <h3 className="mode-section-header">Playing right now</h3>
+          <LobbyBoardSection
+            board={openGames}
+            pods={publicPods}
+            karabast={karabast}
+            companionCapable={casualCapable}
+            returnPath="/"
+          />
+        </section>
       </div>
-      {/* The live board, below the fold. The hero and the mode columns are
-          untouched — this is what someone finds when they scroll, rather than
-          something competing with the front door. */}
-      <section className="landing-board" aria-label="Open games">
-        <h2 className="landing-board-title">Playing right now</h2>
-        <LobbyBoardSection
-          board={openGames}
-          pods={publicPods}
-          karabast={karabast}
-          companionCapable={casualCapable}
-          returnPath="/"
-        />
-      </section>
       <SiteFooter />
     </div>
   )

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -1,11 +1,14 @@
 // @ts-nocheck
 'use client'
 
-import { useEffect, useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState, Fragment } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '../contexts/AuthContext'
 import { usePresence } from '../hooks/usePresence'
 import { usePublicPodsSocket } from '../hooks/usePublicPodsSocket'
+import { useOpenGamesSocket } from '../hooks/useOpenGamesSocket'
+import { useKarabastLobbies } from '../hooks/useKarabastLobbies'
+import { useCompanionCapability } from '../hooks/useCompanionCapability'
 import { formatPoolLabel } from '../utils/poolDisplayName'
 import { getUpcomingSetForPromo } from '../utils/membership'
 import {
@@ -16,6 +19,8 @@ import {
 import { trackEvent, AnalyticsEvents } from '../hooks/useAnalytics'
 import ReleaseNotes from './ReleaseNotes'
 import SiteFooter from './SiteFooter'
+import LobbyBoardSection from './Lobby/LobbyBoardSection'
+import './Lobby/Lobby.css'
 import Button from './Button'
 import SubscribeModal from './SubscribeModal'
 import Countdown from './Countdown'
@@ -120,7 +125,13 @@ function LandingPage() {
       setWasRemoved(true)
     }
   }, [])
-  const { count: playerCount } = usePresence(user?.id)
+  const presence = usePresence(user?.id)
+  const playerCount = presence.count
+  // One instance each, shared with the board below: these hooks each open
+  // their own socket, so calling them twice on one page would double up.
+  const openGames = useOpenGamesSocket()
+  const karabast = useKarabastLobbies()
+  const { casualCapable } = useCompanionCapability()
   const publicPods = usePublicPodsSocket()
   const [activeDraft, setActiveDraft] = useState<ActiveDraft | null>(null)
   const [activeSealedPod, setActiveSealedPod] = useState<ActiveSealedPod | null>(null)
@@ -489,7 +500,21 @@ function LandingPage() {
         {playerCount > 0 && (
           <div className="players-online-landing">
             <span className="online-dot-landing" />
-            <span>{playerCount} player{playerCount !== 1 ? 's' : ''} online</span>
+            {/* A bare total reads as a room full of people refusing to play with
+                you. The breakdown says what they're actually doing, and a zero is
+                never a line item — an omission reads as a gap you can fill. */}
+            <span className="landing-live-line">
+              <strong>{playerCount}</strong> online
+              {[
+                openGames.listings.length > 0 && <><strong>{openGames.listings.length}</strong> open {openGames.listings.length === 1 ? 'lobby' : 'lobbies'}</>,
+                publicPods.length > 0 && <><strong>{publicPods.length}</strong> {publicPods.length === 1 ? 'pod' : 'pods'} forming</>,
+                presence.drafting > 0 && <><strong>{presence.drafting}</strong> drafting</>,
+                presence.building > 0 && <><strong>{presence.building}</strong> building</>,
+                presence.browsing > 0 && <><strong>{presence.browsing}</strong> solo play</>,
+              ].filter(Boolean).map((bit, i) => (
+                <Fragment key={i}> · {bit}</Fragment>
+              ))}
+            </span>
           </div>
         )}
         {activeDraft && (
@@ -614,6 +639,19 @@ function LandingPage() {
           </div>
         </div>
       </div>
+      {/* The live board, below the fold. The hero and the mode columns are
+          untouched — this is what someone finds when they scroll, rather than
+          something competing with the front door. */}
+      <section className="landing-board" aria-label="Open games">
+        <h2 className="landing-board-title">Playing right now</h2>
+        <LobbyBoardSection
+          board={openGames}
+          pods={publicPods}
+          karabast={karabast}
+          companionCapable={casualCapable}
+          returnPath="/"
+        />
+      </section>
       <SiteFooter />
     </div>
   )

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -543,6 +543,19 @@ function LandingPage() {
             </Button>
           </div>
         )}
+        {/* Above the mode buttons: what's actually happening comes before the
+            menu of things you could start. Carries .mode-sections-row's own
+            max-width so its edges line up with the buttons below it. */}
+        <section className="landing-board" aria-label="Open games">
+          <h3 className="mode-section-header">Play Now!</h3>
+          <LobbyBoardSection
+            board={openGames}
+            pods={publicPods}
+            karabast={karabast}
+            companionCapable={casualCapable}
+            returnPath="/"
+          />
+        </section>
         <div className="mode-sections-row">
           <div className="mode-section">
             <h3 className="mode-section-header">Solo</h3>
@@ -638,19 +651,6 @@ function LandingPage() {
             </div>
           </div>
         </div>
-        {/* The live board, below the fold. Sits inside .landing-content and
-            carries .mode-sections-row's own max-width, so its edges line up
-            with the button grid above rather than running wider. */}
-        <section className="landing-board" aria-label="Open games">
-          <h3 className="mode-section-header">Playing right now</h3>
-          <LobbyBoardSection
-            board={openGames}
-            pods={publicPods}
-            karabast={karabast}
-            companionCapable={casualCapable}
-            returnPath="/"
-          />
-        </section>
       </div>
       <SiteFooter />
     </div>

--- a/src/components/LandingPage.tsx
+++ b/src/components/LandingPage.tsx
@@ -587,7 +587,7 @@ function LandingPage() {
             </div>
           </div>
           <div className="mode-section">
-            <h3 className="mode-section-header">Live Pod</h3>
+            <h3 className="mode-section-header">With Friends</h3>
             <div className="mode-column">
               <button className="mode-button art-event" onClick={() => router.push('/sealed/pod')}>
                 <div className="mode-button-art" style={{ backgroundImage: `url("${MODE_ART.sealedLive}")` }} />

--- a/src/components/Lobby/DeckPicker.css
+++ b/src/components/Lobby/DeckPicker.css
@@ -19,6 +19,15 @@
   --ys-radius-sm: 10px;
 }
 
+/* The confirm button relabels while the request is in flight ("Create Lobby"
+   -> "Creating…"), which is 21px narrower. .modal-actions is flex-end, so the
+   whole row slid ~20px sideways on click and snapped back on completion — it
+   read as the buttons expanding or duplicating. Reserving the width means the
+   label can change without moving anything. */
+.lobby-deck-modal .modal-actions > :last-child {
+  min-width: 11rem;
+}
+
 /* Karabast join: why the picker isn't filtered for you. */
 .lobby-karabast-note {
   margin: 0 0 var(--pt-space-xs);

--- a/src/components/Lobby/Lobby.css
+++ b/src/components/Lobby/Lobby.css
@@ -522,6 +522,51 @@ a.lobby-row-link:active {
 }
 
 /* seat dots (pods column) */
+/* Pod rows stack: one line of text, then the seat dots and Join beneath it.
+   Side by side, this column is too narrow — the name truncated to "Ash" and
+   the host to "ho...". */
+.lobby-row--pod {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
+
+/* The NAME gives, not the line. Truncating the whole line cut the tail, so
+   host / seats / age — the bits you actually scan — disappeared first. */
+.lobby-pod-line {
+  display: flex;
+  align-items: baseline;
+  min-width: 0;
+  white-space: nowrap;
+  font-size: 0.95rem;
+}
+
+.lobby-pod-line strong {
+  color: var(--pt-ink);
+  font-weight: 600;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.lobby-pod-meta {
+  flex: none;
+  color: var(--pt-ink-subtle);
+  font-size: 0.8rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.lobby-pod-foot {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+/* Join sits at the far end, seats keep the left. */
+.lobby-pod-foot > :last-child {
+  margin-left: auto;
+}
+
 .lobby-seats {
   display: flex;
   gap: 4px;

--- a/src/components/Lobby/Lobby.css
+++ b/src/components/Lobby/Lobby.css
@@ -531,26 +531,23 @@ a.lobby-row-link:active {
   gap: 6px;
 }
 
-/* The NAME gives, not the line. Truncating the whole line cut the tail, so
-   host / seats / age — the bits you actually scan — disappeared first. */
+/* Name over meta, each on its own line. Squeezing both onto one line meant
+   something always had to be cut; two lines costs a little height and cuts
+   nothing. */
 .lobby-pod-line {
-  display: flex;
-  align-items: baseline;
   min-width: 0;
-  white-space: nowrap;
   font-size: 0.95rem;
 }
 
 .lobby-pod-line strong {
+  display: block;
   color: var(--pt-ink);
   font-weight: 600;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
+  line-height: 1.25;
 }
 
 .lobby-pod-meta {
-  flex: none;
+  display: block;
   color: var(--pt-ink-subtle);
   font-size: 0.8rem;
   font-variant-numeric: tabular-nums;

--- a/src/components/Lobby/Lobby.css
+++ b/src/components/Lobby/Lobby.css
@@ -380,10 +380,22 @@
   text-overflow: ellipsis;
 }
 
-/* Name text truncates so the inline set/format tags stay visible. */
+/* Name text truncates so the inline set/format tags stay visible. A flex item
+   defaults to min-width:auto, which refuses to shrink below its content — so
+   without this the ellipsis never engages and a long name (e.g. a Karabast
+   lobby carrying the protectthepod.com suffix) pushes the badges out of the
+   row instead. */
 .lobby-row-name-text {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+/* Badges are the thing the truncation is protecting — never shrink them. */
+.lobby-row-name .lobby-badge,
+.lobby-row-name .lobby-tip,
+.lobby-row-name .lobby-host-dot {
+  flex: none;
 }
 
 .lobby-row-meta {
@@ -463,7 +475,11 @@ a.lobby-row-link:active {
   flex: none;
 }
 
-.lobby-check {
+/* The PTP-validated tick on a Karabast row. Named apart from .lobby-check —
+   the modal's checkbox label owns that name further down this file, and being
+   defined later it was winning, dropping its margin-top and font-size onto
+   this inline marker and making the row two lines tall. */
+.lobby-verified {
   color: var(--pt-glow-primary);
   cursor: help;
   flex: none;

--- a/src/components/Lobby/LobbyBoardSection.tsx
+++ b/src/components/Lobby/LobbyBoardSection.tsx
@@ -1,0 +1,214 @@
+'use client'
+
+/**
+ * The live board plus everything needed to act on it — join, leave, create,
+ * and the Karabast handoff — in one drop-in.
+ *
+ * Extracted from LobbyHome so the homepage can carry the board below the fold
+ * without duplicating ~100 lines of handlers. Both surfaces render this, so a
+ * fix to the join flow lands on both by construction.
+ */
+import { useState, useCallback, useEffect } from 'react'
+import { useRouter } from 'next/navigation'
+import { useAuth } from '@/src/contexts/AuthContext'
+import type { OpenGamesBoard, OpenGameListing } from '@/src/hooks/useOpenGamesSocket'
+import type { PublicPod } from '@/src/hooks/usePublicPodsSocket'
+import type { KarabastLobby } from '@/src/hooks/useKarabastLobbies'
+import {
+  buildWayfinderCasualCreatePayload,
+  karabastLobbyPrivacy,
+} from '@/src/hooks/useWayfinderCasualLaunch'
+import { useToast } from '@/src/components/Toast'
+import LobbyBoard from '@/src/components/Lobby/LobbyBoard'
+import PostGameModal from '@/src/components/Lobby/PostGameModal'
+import JoinGameModal from '@/src/components/Lobby/JoinGameModal'
+import JoinKarabastModal from '@/src/components/Lobby/JoinKarabastModal'
+
+interface LobbyBoardSectionProps {
+  /* Live data is passed IN rather than fetched here: useOpenGamesSocket opens
+     its own socket per call, so a page that also shows counts in its header
+     would otherwise hold two connections and double-fetch the board. The
+     parent owns one instance and shares it. */
+  board: OpenGamesBoard
+  pods: PublicPod[]
+  karabast: { available: boolean; lobbies: KarabastLobby[] }
+  companionCapable: boolean
+  /** Where an anonymous click should land back after Discord OAuth. */
+  returnPath?: string
+  /** R35: play-page CTA preselects the deck for the New Lobby modal. */
+  initialPoolShareId?: string | null
+}
+
+export default function LobbyBoardSection({
+  board,
+  pods,
+  karabast,
+  companionCapable,
+  returnPath = '/',
+  initialPoolShareId = null,
+}: LobbyBoardSectionProps): React.JSX.Element {
+  const router = useRouter()
+  // AuthContext is untyped JSX; the user object is snake_case (documented trap).
+  const { user, loading: authLoading } = useAuth() as {
+    user: { id: string; username?: string } | null
+    loading: boolean
+  }
+  const { showToast } = useToast()
+  const [newGameOpen, setNewGameOpen] = useState(false)
+  const [joinTarget, setJoinTarget] = useState<OpenGameListing | null>(null)
+  const [karabastTarget, setKarabastTarget] = useState<KarabastLobby | null>(null)
+
+  // R26: anonymous action clicks round-trip through Discord OAuth and land
+  // back where they started. The destination re-validates state on return.
+  const requireLogin = useCallback(
+    (intent?: string): boolean => {
+      if (user) return true
+      // Auth still resolving: swallow the click instead of misreading a
+      // logged-in user as anonymous and bouncing them through OAuth.
+      if (authLoading) return false
+      const returnTo = intent ? `${returnPath}${intent}` : returnPath
+      window.location.href = `/api/auth/signin/discord?return_to=${encodeURIComponent(returnTo)}`
+      return false
+    },
+    [user, authLoading, returnPath]
+  )
+
+  // Hash-anchor deep links (house rule: hash, not ?tab=): #new-game opens the
+  // modal, including the post-OAuth return trip.
+  useEffect(() => {
+    if (user && window.location.hash === '#new-game') {
+      setNewGameOpen(true)
+    }
+  }, [user])
+
+  const handleNewGame = useCallback(() => {
+    if (!requireLogin('#new-game')) return
+    setNewGameOpen(true)
+  }, [requireLogin])
+
+  const handleJoin = useCallback(
+    (listing: OpenGameListing) => {
+      if (!requireLogin()) return
+      setJoinTarget(listing)
+    },
+    [requireLogin]
+  )
+
+  // Leave your own listing: DELETE it and let the socket broadcast clear the
+  // row for everyone (including this board). No success toast — the row
+  // disappearing is the feedback.
+  const handleLeave = useCallback(
+    async (listing: OpenGameListing) => {
+      try {
+        const res = await fetch(`/api/open-games/${listing.shareId}`, {
+          method: 'DELETE',
+          credentials: 'include',
+        })
+        if (!res.ok) throw new Error(String(res.status))
+      } catch {
+        showToast({ text: 'Could not remove your lobby — try again.', kind: 'danger' })
+      }
+    },
+    [showToast]
+  )
+
+  // R34 create-at-post: after creating, a capable Companion pre-creates the
+  // public Karabast lobby before anyone joins.
+  const handleCreated = useCallback(
+    async (
+      game: { shareId: string; visibility: string; karabastFindable?: boolean },
+      createKarabastLobby: boolean
+    ) => {
+      setNewGameOpen(false)
+      if (createKarabastLobby) {
+        try {
+          const res = await fetch(`/api/open-games/${game.shareId}/claim`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ companionCapable: true }),
+          })
+          const json = await res.json().catch(() => null)
+          const claim = (json?.data || json)?.claim
+          if (claim?.action === 'create_lobby') {
+            window.postMessage(
+              buildWayfinderCasualCreatePayload({
+                openGameShareId: game.shareId,
+                poolShareId: '',
+                deckUrl: `${window.location.origin}/g/${game.shareId}`,
+                lobbyName: claim.lobbyName || 'protectthepod.com',
+                // One source of truth with the match page's Create Game button:
+                // both derive privacy from the persisted findability flag, so
+                // pre-created and match-time lobbies can't disagree.
+                visibility: karabastLobbyPrivacy(game),
+              }),
+              '*'
+            )
+          }
+        } catch {
+          // Lobby pre-creation is best-effort; the match-time handshake covers it.
+        }
+      }
+      router.push(`/g/${game.shareId}`)
+    },
+    [router]
+  )
+
+  // Karabast lobbies take a deck like any other game: pick one, then the
+  // Companion loads it and drops you into that lobby (wayfinder:join-lobby).
+  // The picker is unfiltered — the relay carries no set or pack count, so the
+  // lobby name is the only signal and the player reads it themselves.
+  const handleJoinKarabast = useCallback((lobby: KarabastLobby) => {
+    setKarabastTarget(lobby)
+  }, [])
+
+  return (
+    <>
+      <LobbyBoard
+        board={board}
+        pods={pods}
+        karabast={karabast}
+        currentUsername={user?.username ?? null}
+        onJoin={handleJoin}
+        onLeave={handleLeave}
+        onNewGame={handleNewGame}
+        onJoinKarabast={handleJoinKarabast}
+      />
+
+      <PostGameModal
+        isOpen={newGameOpen}
+        onClose={() => setNewGameOpen(false)}
+        onCreated={handleCreated}
+        companionCapable={companionCapable}
+        initialPoolShareId={initialPoolShareId}
+      />
+
+      <JoinGameModal
+        isOpen={joinTarget != null}
+        onClose={() => setJoinTarget(null)}
+        game={
+          joinTarget
+            ? {
+              shareId: joinTarget.shareId,
+              setCode: joinTarget.setCode,
+              format: joinTarget.format,
+              // Sealed pack count is part of the format (hard split).
+              packsPerPlayer: joinTarget.packsPerPlayer ?? null,
+              hostUsername: joinTarget.host.username,
+            }
+            : null
+        }
+        onJoined={game => {
+          setJoinTarget(null)
+          router.push(`/g/${game.shareId}`)
+        }}
+      />
+
+      <JoinKarabastModal
+        isOpen={karabastTarget != null}
+        onClose={() => setKarabastTarget(null)}
+        lobby={karabastTarget}
+      />
+    </>
+  )
+}

--- a/src/components/Lobby/LobbyHome.tsx
+++ b/src/components/Lobby/LobbyHome.tsx
@@ -11,17 +11,12 @@ import { useState, useCallback, useEffect, Suspense, Fragment } from 'react'
 import { useRouter, useSearchParams } from 'next/navigation'
 import { useAuth } from '@/src/contexts/AuthContext'
 import { usePresence } from '@/src/hooks/usePresence'
-import { useOpenGamesSocket, type OpenGameListing } from '@/src/hooks/useOpenGamesSocket'
+import { useOpenGamesSocket } from '@/src/hooks/useOpenGamesSocket'
 import { usePublicPodsSocket } from '@/src/hooks/usePublicPodsSocket'
-import { useKarabastLobbies, type KarabastLobby } from '@/src/hooks/useKarabastLobbies'
+import { useKarabastLobbies } from '@/src/hooks/useKarabastLobbies'
 import { useCompanionCapability } from '@/src/hooks/useCompanionCapability'
-import { buildWayfinderCasualCreatePayload, karabastLobbyPrivacy } from '@/src/hooks/useWayfinderCasualLaunch'
-import { useToast } from '@/src/components/Toast'
 import { MODE_ART } from '@/src/components/LandingPage'
-import LobbyBoard from '@/src/components/Lobby/LobbyBoard'
-import PostGameModal from '@/src/components/Lobby/PostGameModal'
-import JoinGameModal from '@/src/components/Lobby/JoinGameModal'
-import JoinKarabastModal from '@/src/components/Lobby/JoinKarabastModal'
+import LobbyBoardSection from '@/src/components/Lobby/LobbyBoardSection'
 import ReleaseNotes from '@/src/components/ReleaseNotes'
 import SiteFooter from '@/src/components/SiteFooter'
 import '@/src/components/LandingPage.css'
@@ -82,16 +77,12 @@ function LobbyPageInner(): React.JSX.Element {
   const router = useRouter()
   const searchParams = useSearchParams()
   // AuthContext is untyped JSX; the user object is snake_case (documented trap).
-  const { user, loading: authLoading } = useAuth() as { user: { id: string; username?: string } | null; loading: boolean }
+  const { user } = useAuth() as { user: { id: string; username?: string } | null }
   const presence = usePresence(user?.id)
   const board = useOpenGamesSocket()
   const pods = usePublicPodsSocket()
   const karabast = useKarabastLobbies()
   const { casualCapable } = useCompanionCapability()
-  const { showToast } = useToast()
-  const [newGameOpen, setNewGameOpen] = useState(false)
-  const [joinTarget, setJoinTarget] = useState<OpenGameListing | null>(null)
-  const [karabastTarget, setKarabastTarget] = useState<KarabastLobby | null>(null)
   // R35: play-page CTA arrives as /lobby?pool=<shareId>#new-game
   const preselectPool = searchParams.get('pool')
 
@@ -127,107 +118,6 @@ function LobbyPageInner(): React.JSX.Element {
       localStorage.setItem(DISCORD_CTA_CLICKED_KEY, '1')
     } catch { /* localStorage disabled */ }
     setDiscordCtaClicked(true)
-  }, [])
-
-  // R26: anonymous action clicks round-trip through Discord OAuth and land
-  // back in the lobby. The destination re-validates state on return.
-  const requireLogin = useCallback((intent?: string): boolean => {
-    if (user) return true
-    // Auth still resolving: swallow the click instead of misreading a
-    // logged-in user as anonymous and bouncing them through OAuth.
-    if (authLoading) return false
-    const returnTo = intent ? `/lobby${intent}` : '/lobby'
-    window.location.href = `/api/auth/signin/discord?return_to=${encodeURIComponent(returnTo)}`
-    return false
-  }, [user, authLoading])
-
-  // Hash-anchor deep links (house rule: hash, not ?tab=): #new-game opens the
-  // modal, including the post-OAuth return trip.
-  useEffect(() => {
-    if (user && window.location.hash === '#new-game') {
-      setNewGameOpen(true)
-    }
-  }, [user])
-
-  const handleNewGame = useCallback(() => {
-    if (!requireLogin('#new-game')) return
-    setNewGameOpen(true)
-  }, [requireLogin])
-
-  const handleJoin = useCallback(
-    (listing: OpenGameListing) => {
-      if (!requireLogin()) return
-      setJoinTarget(listing)
-    },
-    [requireLogin]
-  )
-
-  // Leave your own listing: DELETE it and let the socket broadcast clear the
-  // row for everyone (including this board). No success toast — the row
-  // disappearing is the feedback.
-  const handleLeave = useCallback(
-    async (listing: OpenGameListing) => {
-      try {
-        const res = await fetch(`/api/open-games/${listing.shareId}`, {
-          method: 'DELETE',
-          credentials: 'include',
-        })
-        if (!res.ok) throw new Error(String(res.status))
-      } catch {
-        showToast({ text: 'Could not remove your lobby — try again.', kind: 'danger' })
-      }
-    },
-    [showToast]
-  )
-
-  // R34 create-at-post: after creating, a capable Companion pre-creates the
-  // public Karabast lobby before anyone joins.
-  const handleCreated = useCallback(
-    async (
-      game: { shareId: string; visibility: string; karabastFindable?: boolean },
-      createKarabastLobby: boolean
-    ) => {
-      setNewGameOpen(false)
-      if (createKarabastLobby) {
-        try {
-          const res = await fetch(`/api/open-games/${game.shareId}/claim`, {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            credentials: 'include',
-            body: JSON.stringify({ companionCapable: true }),
-          })
-          const json = await res.json().catch(() => null)
-          const claim = (json?.data || json)?.claim
-          if (claim?.action === 'create_lobby') {
-            window.postMessage(
-              buildWayfinderCasualCreatePayload({
-                openGameShareId: game.shareId,
-                poolShareId: '',
-                deckUrl: `${window.location.origin}/g/${game.shareId}`,
-                lobbyName: claim.lobbyName || 'protectthepod.com',
-                // One source of truth with the match page's Create Game button:
-                // both derive privacy from the persisted findability flag, so
-                // pre-created and match-time lobbies can't disagree.
-                visibility: karabastLobbyPrivacy(game),
-              }),
-              '*'
-            )
-          }
-        } catch {
-          // Lobby pre-creation is best-effort; the match-time handshake covers it.
-        }
-      }
-      router.push(`/g/${game.shareId}`)
-    },
-    [router]
-  )
-
-  // Karabast lobbies take a deck like any other game: pick one, then the
-  // Companion loads it and drops you into that lobby (wayfinder:join-lobby).
-  // The picker is unfiltered — the relay carries no set or pack count, so the
-  // lobby name is the only signal and the player reads it themselves.
-  const handleJoinKarabast = useCallback((lobby: KarabastLobby) => {
-    setKarabastTarget(lobby)
   }, [])
 
   return (
@@ -280,15 +170,14 @@ function LobbyPageInner(): React.JSX.Element {
           </div>
         </header>
 
-        <LobbyBoard
+
+        <LobbyBoardSection
           board={board}
           pods={pods}
           karabast={karabast}
-          currentUsername={user?.username ?? null}
-          onJoin={handleJoin}
-          onLeave={handleLeave}
-          onNewGame={handleNewGame}
-          onJoinKarabast={handleJoinKarabast}
+          companionCapable={casualCapable}
+          returnPath="/lobby"
+          initialPoolShareId={preselectPool}
         />
 
         <div className="lobby-tile-row lobby-tile-row-solo">
@@ -354,40 +243,8 @@ function LobbyPageInner(): React.JSX.Element {
           </a>
         </div>
 
-        <PostGameModal
-          isOpen={newGameOpen}
-          onClose={() => setNewGameOpen(false)}
-          onCreated={handleCreated}
-          companionCapable={casualCapable}
-          initialPoolShareId={preselectPool}
-        />
 
-        <JoinGameModal
-          isOpen={joinTarget != null}
-          onClose={() => setJoinTarget(null)}
-          game={
-            joinTarget
-              ? {
-                shareId: joinTarget.shareId,
-                setCode: joinTarget.setCode,
-                format: joinTarget.format,
-                // Sealed pack count is part of the format (hard split).
-                packsPerPlayer: joinTarget.packsPerPlayer ?? null,
-                hostUsername: joinTarget.host.username,
-              }
-              : null
-          }
-          onJoined={game => {
-            setJoinTarget(null)
-            router.push(`/g/${game.shareId}`)
-          }}
-        />
 
-        <JoinKarabastModal
-          isOpen={karabastTarget != null}
-          onClose={() => setKarabastTarget(null)}
-          lobby={karabastTarget}
-        />
       </div>
       {/* Outside .lobby-page on purpose. The page is capped at 100vh so the
           lobby itself never folds; the footer sits below that, the way a

--- a/src/components/Lobby/OpenGamesColumn.tsx
+++ b/src/components/Lobby/OpenGamesColumn.tsx
@@ -7,6 +7,14 @@ import { shortenLobbyName } from '@/src/utils/lobbyNameDisplay'
 import type { OpenGamesBoard, OpenGameListing } from '@/src/hooks/useOpenGamesSocket'
 import type { KarabastLobby } from '@/src/hooks/useKarabastLobbies'
 
+/** Compact form for narrow rows: "now", "13m", "2h". */
+export function timeAgoShort(iso: string): string {
+  const mins = Math.max(0, Math.round((Date.now() - new Date(iso).getTime()) / 60_000))
+  if (mins < 1) return 'now'
+  if (mins < 60) return `${mins}m`
+  return `${Math.round(mins / 60)}h`
+}
+
 export function timeAgo(iso: string): string {
   const ms = Date.now() - new Date(iso).getTime()
   const mins = Math.max(0, Math.round(ms / 60_000))

--- a/src/components/Lobby/OpenGamesColumn.tsx
+++ b/src/components/Lobby/OpenGamesColumn.tsx
@@ -3,6 +3,7 @@
 import Button from '@/src/components/Button'
 import { getPackArtUrl } from '@/src/utils/packArt'
 import { packCountLabel } from '@/src/utils/sealedFormat'
+import { shortenLobbyName } from '@/src/utils/lobbyNameDisplay'
 import type { OpenGamesBoard, OpenGameListing } from '@/src/hooks/useOpenGamesSocket'
 import type { KarabastLobby } from '@/src/hooks/useKarabastLobbies'
 
@@ -60,14 +61,8 @@ export default function OpenGamesColumn({
 
   return (
     <section className="lobby-column" aria-label="Open lobbies">
-      {/* The create action lives here now that the big "New Lobby" verb is
-          gone. The empty state's own button only shows at zero listings, so
-          without this there'd be no way to open a lobby once the board fills. */}
       <h3 className="lobby-column-title">
         Open Lobbies ({totalCount})
-        <Button variant="primary" size="xs" onClick={onNewGame}>
-          New Lobby
-        </Button>
       </h3>
 
       {/* The rows scroll inside the column so a busy board never grows
@@ -184,7 +179,7 @@ export default function OpenGamesColumn({
               <div className="lobby-row-avatar lobby-row-avatar-unknown" title="Player details unavailable for games listed on Karabast" />
               <div className="lobby-row-who">
                 <div className="lobby-row-name">
-                  <span className="lobby-row-name-text">{lobby.name}</span>
+                  <span className="lobby-row-name-text" title={lobby.name}>{shortenLobbyName(lobby.name)}</span>
                   {lobby.isPtp ? (
                     <span className="lobby-tip lobby-verified" data-tip={PTP_VALIDATED}>✓</span>
                   ) : (

--- a/src/components/Lobby/OpenGamesColumn.tsx
+++ b/src/components/Lobby/OpenGamesColumn.tsx
@@ -154,12 +154,13 @@ export default function OpenGamesColumn({
                 </div>
               </div>
               {isMine ? (
-                // Your own listing: you can't join yourself — discard it instead
-                // (danger treatment: this throws the posted lobby away).
+                // Your own listing: you can't join yourself — take it down
+                // instead. An X, not a bin: this withdraws a posting, it
+                // doesn't destroy the pool or the deck behind it.
                 <Button variant="danger" size="sm" onClick={() => onLeave(listing)}>
                   <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-                    <polyline points="3 6 5 6 21 6" />
-                    <path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+                    <line x1="18" y1="6" x2="6" y2="18" />
+                    <line x1="6" y1="6" x2="18" y2="18" />
                   </svg>
                   Leave
                 </Button>

--- a/src/components/Lobby/OpenGamesColumn.tsx
+++ b/src/components/Lobby/OpenGamesColumn.tsx
@@ -186,7 +186,7 @@ export default function OpenGamesColumn({
                 <div className="lobby-row-name">
                   <span className="lobby-row-name-text">{lobby.name}</span>
                   {lobby.isPtp ? (
-                    <span className="lobby-tip lobby-check" data-tip={PTP_VALIDATED}>✓</span>
+                    <span className="lobby-tip lobby-verified" data-tip={PTP_VALIDATED}>✓</span>
                   ) : (
                     <span className="lobby-tip lobby-warn" data-tip={NON_PTP_WARNING}>⚠</span>
                   )}

--- a/src/components/Lobby/PodsFormingColumn.tsx
+++ b/src/components/Lobby/PodsFormingColumn.tsx
@@ -3,7 +3,8 @@
 import { useRouter } from 'next/navigation'
 import Button from '@/src/components/Button'
 import { getPackArtUrl } from '@/src/utils/packArt'
-import { timeAgo } from './OpenGamesColumn'
+import { shortenLobbyName } from '@/src/utils/lobbyNameDisplay'
+import { timeAgoShort } from './OpenGamesColumn'
 
 interface PublicPod {
   shareId: string
@@ -47,25 +48,31 @@ export default function PodsFormingColumn({ pods }: { pods: PublicPod[] }): Reac
           const artUrl = getPackArtUrl(pod.setCode)
           return (
             <div
-              className={`lobby-row${artUrl ? ' lobby-row--art' : ''}`}
+              className={`lobby-row lobby-row--pod${artUrl ? ' lobby-row--art' : ''}`}
               key={pod.shareId}
               style={artUrl ? ({ ['--row-art' as never]: `url(${artUrl})` }) : undefined}
             >
-              <div className="lobby-row-who">
-                <div className="lobby-row-name">{label}</div>
-                <div className="lobby-row-meta">
-                  host: {pod.host?.username || 'unknown'} · {pod.currentPlayers}/{pod.maxPlayers} ·{' '}
-                  {timeAgo(pod.createdAt)}
+              {/* One line of text, then the seats. This column is the narrow
+                  one, so name + host + seats + Join side by side truncated the
+                  name to "Ash" and the host to "ho...". */}
+              <div className="lobby-pod-line" title={label}>
+                <strong>{shortenLobbyName(label)}</strong>
+                <span className="lobby-pod-meta">
+                  {' · '}{pod.host?.username || 'unknown'}
+                  {' · '}{pod.currentPlayers}/{pod.maxPlayers}
+                  {' · '}{timeAgoShort(pod.createdAt)}
+                </span>
+              </div>
+              <div className="lobby-pod-foot">
+                <div className="lobby-seats" aria-label={`${pod.currentPlayers} of ${pod.maxPlayers} seats filled`}>
+                  {Array.from({ length: Math.min(pod.maxPlayers, 8) }, (_, i) => (
+                    <span key={i} className={`lobby-seat${i < pod.currentPlayers ? ' lobby-seat-filled' : ''}`} />
+                  ))}
                 </div>
+                <Button variant="primary" size="sm" onClick={() => router.push(joinPath)}>
+                  Join
+                </Button>
               </div>
-              <div className="lobby-seats" aria-label={`${pod.currentPlayers} of ${pod.maxPlayers} seats filled`}>
-                {Array.from({ length: Math.min(pod.maxPlayers, 8) }, (_, i) => (
-                  <span key={i} className={`lobby-seat${i < pod.currentPlayers ? ' lobby-seat-filled' : ''}`} />
-                ))}
-              </div>
-              <Button variant="primary" size="sm" onClick={() => router.push(joinPath)}>
-                Join
-              </Button>
             </div>
           )
         })}

--- a/src/components/Lobby/PodsFormingColumn.tsx
+++ b/src/components/Lobby/PodsFormingColumn.tsx
@@ -58,7 +58,7 @@ export default function PodsFormingColumn({ pods }: { pods: PublicPod[] }): Reac
               <div className="lobby-pod-line" title={label}>
                 <strong>{shortenLobbyName(label)}</strong>
                 <span className="lobby-pod-meta">
-                  {' · '}{pod.host?.username || 'unknown'}
+                  {pod.host?.username || 'unknown'}
                   {' · '}{pod.currentPlayers}/{pod.maxPlayers}
                   {' · '}{timeAgoShort(pod.createdAt)}
                 </span>

--- a/src/hooks/usePublicPodsSocket.ts
+++ b/src/hooks/usePublicPodsSocket.ts
@@ -2,7 +2,7 @@
 import { useState, useEffect, useCallback } from 'react'
 import { io as socketIO, Socket } from 'socket.io-client'
 
-interface PublicPod {
+export interface PublicPod {
   shareId: string
   podType: string
   setCode: string

--- a/src/utils/lobbyNameDisplay.test.ts
+++ b/src/utils/lobbyNameDisplay.test.ts
@@ -6,7 +6,7 @@ describe('shortenLobbyName', () => {
   it('SPEC: a full set name becomes its set code', () => {
     assert.strictEqual(
       shortenLobbyName('Ashes of the Empire Competitive Practice'),
-      'ASH Competitive Practice'
+      'ASH Competitive'
     )
     assert.strictEqual(shortenLobbyName('A Lawless Time Draft'), 'LAW Draft')
   })
@@ -33,8 +33,16 @@ describe('shortenLobbyName', () => {
     assert.strictEqual(shortenLobbyName('Friday night games'), 'Friday night games')
   })
 
-  it('does not summarise — unknown words survive', () => {
-    assert.strictEqual(shortenLobbyName('ASH Competitive Practice'), 'ASH Competitive Practice')
+  it('SPEC: a trailing "Practice" is dropped', () => {
+    assert.strictEqual(shortenLobbyName('ASH Competitive Practice'), 'ASH Competitive')
+  })
+
+  it('only drops Practice at the end, never mid-name', () => {
+    assert.strictEqual(shortenLobbyName('Practice makes perfect'), 'Practice makes perfect')
+  })
+
+  it('does not summarise — other unknown words survive', () => {
+    assert.strictEqual(shortenLobbyName('ASH Friday Night Sealed'), 'ASH Friday Night Sealed')
   })
 
   it('falls back rather than rendering an empty row', () => {

--- a/src/utils/lobbyNameDisplay.test.ts
+++ b/src/utils/lobbyNameDisplay.test.ts
@@ -1,0 +1,49 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert'
+import { shortenLobbyName } from './lobbyNameDisplay'
+
+describe('shortenLobbyName', () => {
+  it('SPEC: a full set name becomes its set code', () => {
+    assert.strictEqual(
+      shortenLobbyName('Ashes of the Empire Competitive Practice'),
+      'ASH Competitive Practice'
+    )
+    assert.strictEqual(shortenLobbyName('A Lawless Time Draft'), 'LAW Draft')
+  })
+
+  it('SPEC: drops the protectthepod.com attribution — the row\'s ✓ says it', () => {
+    assert.strictEqual(
+      shortenLobbyName('SEC Draft Leia Splash Green protectthepod.com'),
+      'SEC Draft Leia Splash Green'
+    )
+  })
+
+  it('SPEC: applies both substitutions together', () => {
+    assert.strictEqual(
+      shortenLobbyName('Ashes of the Empire Sealed protectthepod.com'),
+      'ASH Sealed'
+    )
+  })
+
+  it('matches the set name case-insensitively', () => {
+    assert.strictEqual(shortenLobbyName('ashes of the empire sealed'), 'ASH sealed')
+  })
+
+  it('leaves a name with nothing to abbreviate alone', () => {
+    assert.strictEqual(shortenLobbyName('Friday night games'), 'Friday night games')
+  })
+
+  it('does not summarise — unknown words survive', () => {
+    assert.strictEqual(shortenLobbyName('ASH Competitive Practice'), 'ASH Competitive Practice')
+  })
+
+  it('falls back rather than rendering an empty row', () => {
+    assert.strictEqual(shortenLobbyName(''), 'Karabast lobby')
+    assert.strictEqual(shortenLobbyName(null), 'Karabast lobby')
+    assert.strictEqual(shortenLobbyName('   protectthepod.com  '), 'Karabast lobby')
+  })
+
+  it('collapses whitespace left by a removed suffix', () => {
+    assert.ok(!/\s{2,}/.test(shortenLobbyName('ASH Draft  protectthepod.com')))
+  })
+})

--- a/src/utils/lobbyNameDisplay.ts
+++ b/src/utils/lobbyNameDisplay.ts
@@ -1,0 +1,41 @@
+import { SET_CONFIGS } from './setConfigs/index'
+
+/**
+ * Shorten a Karabast lobby name for display in a board row.
+ *
+ * Karabast names are free text and run long — "Ashes of the Empire Competitive
+ * Practice" is 39 characters before any badge. The board column is bounded by
+ * the homepage's button grid, so the name has to give rather than the layout.
+ *
+ * Two substitutions, both things the row is already saying more compactly:
+ *  - a full set name becomes its set code, the abbreviation used on every
+ *    badge, filter chip and deck tag in the app ("Ashes of the Empire" → ASH)
+ *  - the protectthepod.com attribution suffix is dropped, because the row
+ *    already carries the ✓ validated marker that means exactly that
+ *
+ * Anything else is left alone: this abbreviates, it doesn't summarise.
+ */
+
+const PTP_SUFFIX = /\s*protectthepod\.com\s*$/i
+
+/** Longest first, so "A Lawless Time" can't be shadowed by a shorter match. */
+const SET_NAMES: { name: string; code: string }[] = Object.values(SET_CONFIGS)
+  .filter(c => typeof c.setName === 'string' && c.setName.length > 0)
+  .map(c => ({ name: String(c.setName), code: String(c.setCode) }))
+  .sort((a, b) => b.name.length - a.name.length)
+
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+export function shortenLobbyName(raw: string | null | undefined): string {
+  let name = (raw || '').trim()
+  if (!name) return 'Karabast lobby'
+  name = name.replace(PTP_SUFFIX, '').trim()
+  for (const { name: full, code } of SET_NAMES) {
+    name = name.replace(new RegExp(escapeRegExp(full), 'gi'), code)
+  }
+  // Collapse whitespace left behind by a removed suffix.
+  name = name.replace(/\s{2,}/g, ' ').trim()
+  return name || 'Karabast lobby'
+}

--- a/src/utils/lobbyNameDisplay.ts
+++ b/src/utils/lobbyNameDisplay.ts
@@ -12,11 +12,14 @@ import { SET_CONFIGS } from './setConfigs/index'
  *    badge, filter chip and deck tag in the app ("Ashes of the Empire" → ASH)
  *  - the protectthepod.com attribution suffix is dropped, because the row
  *    already carries the ✓ validated marker that means exactly that
+ *  - a trailing "Practice" is dropped: "Competitive Practice" is Competitive
  *
  * Anything else is left alone: this abbreviates, it doesn't summarise.
  */
 
 const PTP_SUFFIX = /\s*protectthepod\.com\s*$/i
+/** "Competitive Practice" is just Competitive — the noun adds nothing. */
+const PRACTICE_SUFFIX = /\s+practice\s*$/i
 
 /** Longest first, so "A Lawless Time" can't be shadowed by a shorter match. */
 const SET_NAMES: { name: string; code: string }[] = Object.values(SET_CONFIGS)
@@ -32,6 +35,7 @@ export function shortenLobbyName(raw: string | null | undefined): string {
   let name = (raw || '').trim()
   if (!name) return 'Karabast lobby'
   name = name.replace(PTP_SUFFIX, '').trim()
+  name = name.replace(PRACTICE_SUFFIX, '').trim()
   for (const { name: full, code } of SET_NAMES) {
     name = name.replace(new RegExp(escapeRegExp(full), 'gi'), code)
   }


### PR DESCRIPTION
**For review — not merging.** This reverts the lobby-as-homepage flip and layers live state onto the homepage you had instead.

Mocks this implements: **A + D** from the review page — the presence breakdown, and the board below the fold.

## What changed on `/`

The hero, Discord CTA and the three mode columns are byte-for-byte what they were. Two things added:

- **The presence line says what people are doing.** Was "13 players online"; now `13 online · 2 open lobbies · 4 building · 9 solo play`. A zero is never a line item — an activity that isn't happening is omitted, not shown as `0`.
- **The board sits under the columns** as "Playing right now" — open lobbies, pods, and the Karabast games. Scroll and you get everything; don't, and the homepage is the one you've always had.

## Two structural calls

**One copy of the board logic.** Join, leave, create, the Karabast handoff and all three modals moved into `LobbyBoardSection`, rendered by both `/` and `/lobby`. Otherwise two copies of `handleCreated` — with its Karabast claim and casual-intent payload — would sit in two files and drift apart. That drift is the exact bug class that produced the private-lobby-published-to-Karabast issue earlier.

**The section takes live data as props, not hooks.** `useOpenGamesSocket` opens its *own socket per call*. The homepage now shows counts in the header *and* the board, so calling the hook in both places would mean two sockets and two board fetches per visitor. The page owns one instance and shares it — verified: **1** `/api/open-games` fetch, **1** `/api/pods/public` fetch.

## Verified

- `/` — old homepage back, live strip reads `1 online · 1 solo play`, board present below the columns
- `/lobby` — unchanged: board, both tile rows, Discord tile, zero page overflow
- `/terms-of-service` — still 200, still renders Terms
- typecheck, ts-ratchet, design-tells, lint, `npm run test` (2474 tests, **0 fail**), production build — all green

## Not included

No release note yet — this is a user-visible revert of what shipped as `08.01.2026 Part 3`, and how to describe that depends on whether you want it framed as a change of direction or just quietly adjusted. Tell me which and I'll write it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)